### PR TITLE
Dev/symlink support

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -8,6 +8,7 @@ Dimitri Merejkowsky
 Théo Delrieu
 Jakob Heuser
 Tronje Krabbe
+Matthew Lovell
 
 
 If you make a contribution, feel free to make a pull request to add your name

--- a/tsrc/__init__.py
+++ b/tsrc/__init__.py
@@ -7,7 +7,7 @@ from .errors import Error, InvalidConfig  # noqa
 from .executor import Task, run_sequence, ExecutorFailed  # noqa
 from .groups import GroupList, Group  # noqa
 from .groups import GroupNotFound, UnknownElement as UnknownGroupElement  # noqa
-from .repo import Repo, Remote, Copy  # noqa
+from .repo import Repo, Remote, Copy, Link  # noqa
 from .manifest import Manifest  # noqa
 from .manifest import load as load_manifest  # noqa
 from .workspace import Workspace  # noqa

--- a/tsrc/manifest.py
+++ b/tsrc/manifest.py
@@ -30,6 +30,7 @@ class Manifest:
         for repo_config in repos_config:
             self._handle_repo(repo_config)
             self._handle_copies(repo_config)
+            self._handle_links(repo_config)
 
         groups_config = config.get("groups")
         self._handle_groups(groups_config)
@@ -64,16 +65,20 @@ class Manifest:
             return
         to_cp = repo_config["copy"]
         for item in to_cp:
-            if "file" in item:
-                src = item["file"]
-                dest = item.get("dest", src)
-                copy = tsrc.Copy(repo_config["dest"], src, dest)
-                self.copyfiles.append(copy)
-            elif "symlink" in item:
-                src = item["symlink"]
-                dest = item.get("dest", src)
-                link = tsrc.Link(src, dest)
-                self.symlinks.append(link)
+            src = item["file"]
+            dest = item.get("dest", src)
+            copy = tsrc.Copy(repo_config["dest"], src, dest)
+            self.copyfiles.append(copy)
+
+    def _handle_links(self, repo_config: Any) -> None:
+        if "symlink" not in repo_config:
+            return
+        to_link = repo_config["symlink"]
+        for item in to_link:
+            src = item["source"]
+            tgt = item.get("target", src)
+            link = tsrc.Link(src, tgt)
+            self.symlinks.append(link)
 
     def _handle_groups(self, groups_config: Any) -> None:
         elements = {repo.dest for repo in self._repos}
@@ -119,16 +124,15 @@ class Manifest:
 
 
 def validate_repo(data: Any) -> None:
-    copy_schema = {
-        schema.Or("file", "symlink", only_one=True): str,
-        schema.Optional("dest"): str,
-    }
+    copy_schema = {"file": str, schema.Optional("dest"): str}
+    symlink_schema = {"source": str, "target": str}
     remote_schema = {"name": str, "url": str}
     repo_schema = schema.Schema(
         {
             "dest": str,
             schema.Optional("branch"): str,
             schema.Optional("copy"): [copy_schema],
+            schema.Optional("symlink"): [symlink_schema],
             schema.Optional("sha1"): str,
             schema.Optional("tag"): str,
             schema.Optional("remotes"): [remote_schema],

--- a/tsrc/repo.py
+++ b/tsrc/repo.py
@@ -18,6 +18,19 @@ class Copy:
 
 
 @attr.s(frozen=True)
+class Link:
+    src = attr.ib()  # type: str
+    dest = attr.ib()  # type: str
+
+
+@attr.s(frozen=True)
+class CopyDir:
+    repo = attr.ib()  # type: str
+    src = attr.ib()  # type: str
+    dest = attr.ib()  # type: str
+
+
+@attr.s(frozen=True)
 class Repo:
     dest = attr.ib()  # type: str
     remotes = attr.ib()  # type: List[Remote]

--- a/tsrc/repo.py
+++ b/tsrc/repo.py
@@ -20,7 +20,7 @@ class Copy:
 @attr.s(frozen=True)
 class Link:
     src = attr.ib()  # type: str
-    dest = attr.ib()  # type: str
+    tgt = attr.ib()  # type: str
 
 
 @attr.s(frozen=True)

--- a/tsrc/workspace/__init__.py
+++ b/tsrc/workspace/__init__.py
@@ -13,6 +13,7 @@ import tsrc.git
 
 from .cloner import Cloner
 from .copier import FileCopier
+from .linker import FileLinker
 from .syncer import Syncer
 from .remote_setter import RemoteSetter
 from .local_manifest import LocalManifest
@@ -86,9 +87,12 @@ class Workspace:
     def copy_files(self) -> None:
         repos = self.get_repos()
         file_copier = FileCopier(self.root_path, repos)
+        file_linker = FileLinker(self.root_path, repos)
         manifest = self.local_manifest.get_manifest()
         copyfiles = manifest.copyfiles
         tsrc.executor.run_sequence(copyfiles, file_copier)
+        symlinks = manifest.symlinks
+        tsrc.executor.run_sequence(symlinks, file_linker)
 
     def sync(self, *, force: bool = False) -> None:
         syncer = Syncer(

--- a/tsrc/workspace/linker.py
+++ b/tsrc/workspace/linker.py
@@ -20,18 +20,18 @@ class FileLinker(tsrc.executor.Task[tsrc.Link]):
         ui.error("Failed to create the following symlinks:")
 
     def display_item(self, item: tsrc.Link) -> str:
-        return f"{item.dest} linking to {item.src}"
+        return f"{item.src} linking to {item.tgt}"
 
     def process(self, index: int, count: int, item: tsrc.Link) -> None:
-        ui.info_count(index, count, "Linking", item.dest, "->", item.src)
+        ui.info_count(index, count, "Linking", item.src, "->", item.tgt)
         # Both paths are assumed to already be workspace-relative
         src_path = Path(item.src)
-        dest_path = Path(item.dest)
-        if dest_path.isabs():
-            ui.error("Absolute path specified as symlink dest:", dest_path)
+        tgt_path = Path(item.tgt)
+        if src_path.isabs():
+            ui.error("Absolute path specified as symlink name:", src_path)
             return
         try:
-            final_dest = self.workspace_path / item.dest
-            os.symlink(src_path, final_dest, src_path.isdir())
+            full_src = self.workspace_path / item.src
+            os.symlink(tgt_path, full_src, tgt_path.isdir())
         except Exception as e:
             raise tsrc.Error(str(e))

--- a/tsrc/workspace/linker.py
+++ b/tsrc/workspace/linker.py
@@ -1,0 +1,36 @@
+from typing import List
+
+import cli_ui as ui
+from path import Path
+
+import tsrc
+import tsrc.executor
+import os
+
+class FileLinker(tsrc.executor.Task[tsrc.Link]):
+    def __init__(self, workspace_path: Path, repos: List[tsrc.Repo]) -> None:
+        self.workspace_path = workspace_path
+        self.repos = repos
+
+    def on_start(self, *, num_items: int) -> None:
+        ui.info_2("Creating symlinks")
+
+    def on_failure(self, *, num_errors: int) -> None:
+        ui.error("Failed to create the following symlinks:")
+
+    def display_item(self, item: tsrc.Link) -> str:
+        return f"{item.dest} linking to {item.src}"
+
+    def process(self, index: int, count: int, item: tsrc.Link) -> None:
+        ui.info_count(index, count, "Linking", item.dest, "->", item.src)
+        # Both paths are assumed to already be workspace-relative
+        src_path = Path(item.src)
+        dest_path = Path(item.dest)
+        if dest_path.isabs():
+            ui.error("Absolute path specified as symlink dest:", dest_path)
+            return
+        try:
+            final_dest = self.workspace_path / item.dest
+            os.symlink(src_path, final_dest, src_path.isdir())
+        except Exception as e:
+            raise tsrc.Error(str(e))

--- a/tsrc/workspace/linker.py
+++ b/tsrc/workspace/linker.py
@@ -7,6 +7,7 @@ import tsrc
 import tsrc.executor
 import os
 
+
 class FileLinker(tsrc.executor.Task[tsrc.Link]):
     def __init__(self, workspace_path: Path, repos: List[tsrc.Repo]) -> None:
         self.workspace_path = workspace_path


### PR DESCRIPTION
This pull request is really just for (light) review.  Presently, the changes to manifest file syntax have -symlink sections under -copy; per email with Dimitri, he would prefer a separate section.  I'll work on changing that.  The change is intended to help with Issue  #43.

I also need to update documentation and unit tests. :)

The Linux machines available to me at work are somewhat ancient, so I'm having issues there getting poetry fully installed (it's bombing out with libgit2 for pygit2).  Thus am I also trying out a copy of the changes under Cygwin on my laptop.  Unfortunately, there I ran into an issue when lint.sh got to the documentation step (see Issue #245).

[Update: Subsequent pushes should have the symlink schema now aligned with Dimitri's stated preference.  No unit tests yet, and email address confusing (work vs private) prevented any success at signing anything.]